### PR TITLE
Add test-after-pull-request agent skill

### DIFF
--- a/.cursor/skills/test-after-pull-request/SKILL.md
+++ b/.cursor/skills/test-after-pull-request/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: test-after-pull-request
+description: Run the project's test suite after creating or updating a pull request. Use when a PR was just created or updated, when finishing agent work before handoff, or when the user asks to test after a PR.
+---
+
+# Test After Pull Request
+
+Verify changes by running tests **after** the pull request exists and changes are pushed. Do not treat a PR as ready until checks pass.
+
+## When to Use
+
+- Immediately after creating or updating a pull request
+- At the end of an agent task that opened or modified a PR
+- When the user asks to "test after PR", "verify the PR", or "run checks before merge"
+- Before marking work complete on a branch with an open PR
+
+## Prerequisites
+
+1. All changes are **committed and pushed** to the PR branch
+2. The PR is created or updated for that pushed revision
+3. Dependencies are installed if needed (`npm install`, `pip install`, etc.)
+
+If you have uncommitted changes, commit and push first, then update the PR, then run this workflow.
+
+## Instructions
+
+### 1. Discover available checks
+
+Inspect the project to find how it validates code. Look in this order:
+
+| Source | What to look for |
+|--------|------------------|
+| `package.json` scripts | `test`, `test:unit`, `test:e2e`, `lint`, `typecheck`, `build`, `check` |
+| `Makefile` | `test`, `check`, `ci` targets |
+| `pyproject.toml` / `setup.cfg` | pytest, ruff, mypy configuration |
+| `.github/workflows/` | CI job commands (use the same commands locally) |
+| `Cargo.toml`, `go.mod`, `pom.xml` | Language-specific test and lint commands |
+
+If no test script exists but test files are present (e.g. `*.test.ts`, `*_test.go`, `test_*.py`), identify the test runner from config files (`vitest.config.*`, `jest.config.*`, `pytest.ini`) and run the appropriate command.
+
+### 2. Run checks in order
+
+Run applicable checks from fastest feedback to slowest:
+
+1. **Lint / format** — catch style and static issues early
+2. **Type check** — if the project uses TypeScript, mypy, etc.
+3. **Unit / integration tests** — the main test suite
+4. **Build** — confirm the project compiles or bundles successfully
+
+Use the shell to run each command. Do not skip a category that exists in the project just because a prior step failed — run all checks so the PR summary reflects the full picture.
+
+### 3. Handle failures
+
+If any check fails:
+
+1. Read the full error output and identify the root cause
+2. Fix the issue with a minimal, focused change
+3. Commit and push the fix to the same PR branch
+4. Re-run the full check sequence from step 2
+5. Repeat until all checks pass or you are blocked and need user input
+
+Do not mark the task complete or leave the PR in a "ready" state with failing checks.
+
+### 4. Report results
+
+After checks complete, summarize in your response:
+
+- Which commands ran
+- Pass/fail status for each
+- Any fixes applied during the test loop
+- Whether the PR branch is green and ready for review
+
+Optionally add a brief comment to the PR body or update the existing PR description with the test results if the workflow context expects it.
+
+## Project Notes (this repo)
+
+This is a React + TypeScript + Vite project. Current validation commands:
+
+```bash
+npm run lint      # ESLint
+npm run build     # TypeScript compile + Vite production build
+```
+
+Test files exist under `src/` (`App.test.tsx`, `setupTests.ts`) but no `test` script is defined in `package.json` yet. If adding or running tests, configure a runner (e.g. Vitest) first, then include `npm test` in this workflow.
+
+## Anti-patterns
+
+- Creating a PR but skipping verification because "the change is small"
+- Running only lint and skipping build/tests when both exist
+- Declaring success without actually executing commands in the shell
+- Leaving failing tests for the reviewer to discover


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor agent skill at `.cursor/skills/test-after-pull-request/SKILL.md` that instructs the agent to run validation checks after creating or updating a pull request.

## What the skill does

- Discovers test, lint, typecheck, and build commands from project config (`package.json`, CI workflows, etc.)
- Runs checks in order (lint → typecheck → tests → build)
- Fixes failures, re-runs checks, and reports results before marking work complete
- Includes project-specific notes for this React/Vite repo

## How to use

- **Automatic:** The agent applies this skill when relevant (after PR creation/update)
- **Manual:** Type `/test-after-pull-request` in Agent chat

## Verification

- Skill file follows the official Cursor `SKILL.md` format (YAML frontmatter + markdown body)
- `npm run lint` reports pre-existing errors in the codebase (unrelated to this change)
- No code changes beyond the skill definition

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-802dde49-a115-41cf-a64c-58d161744ecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-802dde49-a115-41cf-a64c-58d161744ecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

